### PR TITLE
chore: Add --diff-filter option for filtering diff

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
-    "lint-diff": "eslint $(git diff --name-only origin/$BASE origin/$HEAD | grep -E '\\.((j|t)sx?)$' | xargs)",
+    "lint-diff": "eslint $(git diff --name-only --diff-filter=duxb origin/$BASE origin/$HEAD | grep -E '\\.((j|t)sx?)$' | xargs)",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",


### PR DESCRIPTION
## What does this PR do?

<!-- Fill the description of this PR below -->
Prevent `lint-diff` script from checking deleted files

Closes #5 

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Code improvements
- [ ] Breaking change
- [ ] Documentation
- [ ] etc.

## Changes

- Add `--diff-filter=duxb` to `lint-diff` script
  - d: deleted
  - u: unmerged
  - x: unknown
  - b: broken